### PR TITLE
sumcheck and replace with new model weight

### DIFF
--- a/spacer/caffe_utils.py
+++ b/spacer/caffe_utils.py
@@ -9,7 +9,10 @@ from functools import lru_cache
 from typing import List, Any, Tuple
 
 import caffe
+import hashlib
 import numpy as np
+
+from spacer import config
 
 
 class Transformer:
@@ -96,6 +99,11 @@ def load_net(modeldef_path: str,
     :param modelweighs_path: pretrained weights path.
     :return: pretrained model.
     """
+    # To verify that the correct weight is loaded
+    with open(modelweighs_path, 'rb') as fp:
+        sha256 = hashlib.sha256(fp.read()).hexdigest()
+    assert sha256 == config.MODEL_WEIGHTS_SHA['vgg16']
+
     return caffe.Net(modeldef_path, modelweighs_path, caffe.TEST)
 
 

--- a/spacer/caffe_utils.py
+++ b/spacer/caffe_utils.py
@@ -4,6 +4,7 @@ simplicity. Since support for Caffe will be deprecate,
 these are only lightly cleaned up from their original state.
 """
 
+import logging
 from copy import copy
 from functools import lru_cache
 from typing import List, Any, Tuple
@@ -105,8 +106,9 @@ def load_net(modeldef_path: str,
     with open(modelweighs_path, 'rb') as fp:
         sha256 = hashlib.sha256(fp.read()).hexdigest()
     assert sha256 == config.MODEL_WEIGHTS_SHA['vgg16']
-    print("==> time spent on checking sha: {}".format(time.time() - start))
-
+    logging.debug("-> Time spent on checking SHA: {}".format(
+        time.time() - start
+    ))
     return caffe.Net(modeldef_path, modelweighs_path, caffe.TEST)
 
 
@@ -128,9 +130,7 @@ def classify_from_patchlist(patchlist: List,
     """
     # Setup caffe
     caffe.set_mode_cpu()
-    start = time.time()
     net = load_net(modeldef_path, modelweighs_path)
-    print("==> time spent in total: {}".format(time.time() - start))
 
     # Classify
     transformer = Transformer(pyparams['im_mean'])

--- a/spacer/caffe_utils.py
+++ b/spacer/caffe_utils.py
@@ -9,6 +9,7 @@ from functools import lru_cache
 from typing import List, Any, Tuple
 
 import caffe
+import time
 import hashlib
 import numpy as np
 
@@ -100,9 +101,11 @@ def load_net(modeldef_path: str,
     :return: pretrained model.
     """
     # To verify that the correct weight is loaded
+    start = time.time()
     with open(modelweighs_path, 'rb') as fp:
         sha256 = hashlib.sha256(fp.read()).hexdigest()
     assert sha256 == config.MODEL_WEIGHTS_SHA['vgg16']
+    print("==> time spent on checking sha: {}".format(time.time() - start))
 
     return caffe.Net(modeldef_path, modelweighs_path, caffe.TEST)
 
@@ -125,7 +128,9 @@ def classify_from_patchlist(patchlist: List,
     """
     # Setup caffe
     caffe.set_mode_cpu()
+    start = time.time()
     net = load_net(modeldef_path, modelweighs_path)
+    print("==> time spent in total: {}".format(time.time() - start))
 
     # Classify
     transformer = Transformer(pyparams['im_mean'])

--- a/spacer/config.py
+++ b/spacer/config.py
@@ -106,6 +106,13 @@ FEATURE_EXTRACTOR_NAMES = [
     'efficientnet_b0_ver1'
 ]
 
+MODEL_WEIGHTS_SHA = {
+    'vgg16':
+        'fb83781de0e207ded23bd42d7eb6e75c1e915a6fbef74120f72732984e227cca',
+    'efficientnet-b0':
+        'c3dc6d304179c6729c0a0b3d4e60c728bdcf0d82687deeba54af71827467204c',
+}
+
 TRAINER_NAMES = [
     'minibatch'
 ]

--- a/spacer/extract_features.py
+++ b/spacer/extract_features.py
@@ -119,7 +119,7 @@ class EfficientNetExtractor(FeatureExtractor):
 
         # Cache models locally.
         self.modelweighs_path, self.model_was_cashed = download_model(
-            'efficientnetb0_5eps_best.pt')
+            'efficientnet_b0_ver1.pt')
 
     def __call__(self, im, rowcols):
 
@@ -129,7 +129,7 @@ class EfficientNetExtractor(FeatureExtractor):
         torch_params = {'model_type': 'efficientnet',
                         'model_name': 'efficientnet-b0',
                         'weights_path': self.modelweighs_path,
-                        'num_class': 1279,
+                        'num_class': 1275,
                         'crop_size': 224,
                         'batch_size': 10}
 

--- a/spacer/tests/test_extract_features.py
+++ b/spacer/tests/test_extract_features.py
@@ -287,7 +287,7 @@ class TestEfficientNetExtractor(unittest.TestCase):
 
         legacy_feat_loc = DataLocation(storage_type='s3',
                                        key='08bfc10v7t.png.effnet.'
-                                           'featurevector',
+                                           'ver1.featurevector',
                                        bucket_name='spacer-test')
 
         ext = feature_extractor_factory(msg.feature_extractor_name)

--- a/spacer/tests/test_torch_utils.py
+++ b/spacer/tests/test_torch_utils.py
@@ -44,14 +44,14 @@ class TestExtractFeatures(unittest.TestCase):
 
     def setUp(self):
         self.modelweighs_path, self.model_was_cashed = download_model(
-            'efficientnetb0_5eps_best.pt')
+            'efficientnet_b0_ver1.pt')
 
     def test_rgb(self):
 
         torch_params = {'model_type': 'efficientnet',
                         'model_name': 'efficientnet-b0',
                         'weights_path': self.modelweighs_path,
-                        'num_class': 1279,
+                        'num_class': 1275,
                         'crop_size': 224,
                         'batch_size': 10}
         patch_list = [np.array(Image.new('RGB', (224, 224))),

--- a/spacer/torch_utils.py
+++ b/spacer/torch_utils.py
@@ -7,6 +7,7 @@ from typing import Any, List
 
 import numpy as np
 import torch
+import hashlib
 from torchvision import transforms
 
 from spacer import models
@@ -33,6 +34,10 @@ def load_weights(model: Any,
     :param modelweighs_path: pretrained model weight from new CoralNet
     :return: well trained model
     """
+    with open(modelweighs_path, 'rb') as fp:
+        sha256 = hashlib.sha256(fp.read()).hexdigest()
+    assert sha256 == \
+           'c3dc6d304179c6729c0a0b3d4e60c728bdcf0d82687deeba54af71827467204c'
     state_dicts = torch.load(modelweighs_path,
                              map_location=torch.device('cpu'))
     new_state_dicts = OrderedDict()

--- a/spacer/torch_utils.py
+++ b/spacer/torch_utils.py
@@ -8,9 +8,11 @@ from typing import Any, List
 import numpy as np
 import torch
 import hashlib
+from io import BytesIO
 from torchvision import transforms
 
 from spacer import models
+from spacer import config
 
 
 def transformation():
@@ -26,20 +28,21 @@ def transformation():
 
 
 def load_weights(model: Any,
-                 modelweighs_path: str) -> Any:
+                 pyparams: dict) -> Any:
     """
     Load model weights, original weight saved with DataParallel
     Create new OrderedDict that does not contain `module`.
     :param model: Currently support EfficientNet
-    :param modelweighs_path: pretrained model weight from new CoralNet
+    :param pyparams: model parameters
     :return: well trained model
     """
-    with open(modelweighs_path, 'rb') as fp:
-        sha256 = hashlib.sha256(fp.read()).hexdigest()
-    assert sha256 == \
-           'c3dc6d304179c6729c0a0b3d4e60c728bdcf0d82687deeba54af71827467204c'
-    state_dicts = torch.load(modelweighs_path,
-                             map_location=torch.device('cpu'))
+    # Load weights from io.BytesIO object
+    with open(pyparams['weights_path'], 'rb') as fp:
+        buffer = fp.read()
+        sha256 = hashlib.sha256(buffer).hexdigest()
+    assert sha256 == config.MODEL_WEIGHTS_SHA[pyparams['model_name']]
+
+    state_dicts = torch.load(BytesIO(buffer), map_location=torch.device('cpu'))
     new_state_dicts = OrderedDict()
     for k, v in state_dicts['net'].items():
         name = k[7:]
@@ -62,7 +65,7 @@ def extract_feature(patch_list: List,
     net = models.get_model(model_type=pyparams['model_type'],
                            model_name=pyparams['model_name'],
                            num_classes=pyparams['num_class'])
-    net = load_weights(net, pyparams['weights_path'])
+    net = load_weights(net, pyparams)
     net.eval()
 
     transformer = transformation()


### PR DESCRIPTION
- new model weight uploaded to spacer-tools with a name of `efficientnet_b0_ver1.pt`
- `num_class` changed to `1275`
- add `sha256` sumcheck to verify downloading the weights correctly
- since using the new model weight, the legacy test feature is regenerated.