### PR TITLE
Changed to compressed numpy array for storing features

### DIFF
--- a/scripts/aws/batch_large.py
+++ b/scripts/aws/batch_large.py
@@ -29,10 +29,10 @@ def run(job_queue: str = 'shakeout'):
             runtime[job_id]
         ])
 
-    json.dump(to_store, open('runtimes_shakeout.json', 'w'))
+    json.dump(to_store, open('runtimes.json', 'w'))
 
 
-def render(filename='runtimes_shakeout.json'):
+def render(filename='runtimes.json'):
 
     data = json.load(open(filename))
     fig, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=(12, 4))
@@ -78,7 +78,7 @@ def render(filename='runtimes_shakeout.json'):
     ax1.set_ylabel('Runtime (s)')
     ax1.legend()
     plt.show()
-
+    fig.savefig('/Users/beijbom/Desktop/both_runtime.jpg')
 
 if __name__ == '__main__':
     render()

--- a/scripts/aws/batch_large.py
+++ b/scripts/aws/batch_large.py
@@ -29,10 +29,10 @@ def run(job_queue: str = 'shakeout'):
             runtime[job_id]
         ])
 
-    json.dump(to_store, open('runtimes.json', 'w'))
+    json.dump(to_store, open('runtimes_shakeout.json', 'w'))
 
 
-def render(filename='runtimes.json'):
+def render(filename='runtimes_shakeout.json'):
 
     data = json.load(open(filename))
     fig, (ax1, ax2, ax3) = plt.subplots(1, 3, figsize=(12, 4))
@@ -78,7 +78,7 @@ def render(filename='runtimes.json'):
     ax1.set_ylabel('Runtime (s)')
     ax1.legend()
     plt.show()
-    fig.savefig('/Users/beijbom/Desktop/both_runtime.jpg')
+
 
 if __name__ == '__main__':
     render()

--- a/spacer/data_classes.py
+++ b/spacer/data_classes.py
@@ -205,7 +205,7 @@ class ImageFeatures(DataClass):
         )
 
     def serialize(self):
-        raise DeprecationWarning('Use .store() and .load() methods instead.')
+        raise NotImplementedError('Use .store() and .load() methods instead.')
 
     def __eq__(self, other):
         return all([a == b for a, b in zip(self.point_features,

--- a/spacer/data_classes.py
+++ b/spacer/data_classes.py
@@ -115,18 +115,18 @@ class PointFeatures(DataClass):
     def __init__(self,
                  row: Optional[int],  # Row where feature was extracted
                  col: Optional[int],  # Column where feature was extracted
-                 data: np.array,  # Feature vector with half precision floats.
+                 data: np.array,  # Feature vector with 32 bit precision.
                  ):
         self.row = row
         self.col = col
-        self.data = np.array(data, dtype=np.half)
+        self.data = np.array(data, dtype=np.float)
 
     @classmethod
     def example(cls):
         return cls(
             row=100,
             col=100,
-            data=np.array([1.1, 1.3, 1.12], dtype=np.half)
+            data=np.array([1.1, 1.3, 1.12], dtype=np.float)
         )
 
     def __eq__(self, other):
@@ -265,7 +265,7 @@ class ImageFeatures(DataClass):
         else:
             rows = np.array([])
             cols = np.array([])
-        feat = np.array([p.data for p in self.point_features], dtype=np.half)
+        feat = np.array([p.data for p in self.point_features], dtype=np.float)
         meta = np.array([self.valid_rowcol, self.npoints, self.feature_dim])
         output = BytesIO()
         np.savez_compressed(output, meta=meta, rows=rows, cols=cols, feat=feat)

--- a/spacer/data_classes.py
+++ b/spacer/data_classes.py
@@ -119,14 +119,14 @@ class PointFeatures(DataClass):
                  ):
         self.row = row
         self.col = col
-        self.data = np.array(data, dtype=np.float)
+        self.data = np.array(data, dtype=np.half)
 
     @classmethod
     def example(cls):
         return cls(
             row=100,
             col=100,
-            data=np.array([1.1, 1.3, 1.12], dtype=np.float)
+            data=np.array([1.1, 1.3, 1.12], dtype=np.half)
         )
 
     def __eq__(self, other):
@@ -265,7 +265,7 @@ class ImageFeatures(DataClass):
         else:
             rows = np.array([])
             cols = np.array([])
-        feat = np.array([p.data for p in self.point_features], dtype=np.float)
+        feat = np.array([p.data for p in self.point_features], dtype=np.half)
         meta = np.array([self.valid_rowcol, self.npoints, self.feature_dim])
         output = BytesIO()
         np.savez_compressed(output, meta=meta, rows=rows, cols=cols, feat=feat)

--- a/spacer/data_classes.py
+++ b/spacer/data_classes.py
@@ -233,8 +233,8 @@ class ImageFeatures(DataClass):
 
         storage = storage_factory(loc.storage_type, loc.bucket_name)
         stream = storage.load(loc.key)
+        stream.seek(0)
         try:
-            stream.seek(0)
             data = np.load(stream)
             valid_rowcol = data['meta'][0]
             if valid_rowcol:
@@ -250,15 +250,8 @@ class ImageFeatures(DataClass):
                     feature_dim=data['meta'][2]
                 )
             else:
-                return ImageFeatures(
-                    point_features=[PointFeatures(
-                        row=None,
-                        col=None,
-                        data=feat) for feat in data['feat']],
-                    valid_rowcol=data['meta'][0],
-                    npoints=data['meta'][1],
-                    feature_dim=data['meta'][2]
-                )
+                return cls.deserialize(data['feat'].tolist())
+
         except ValueError:
             "We used to store these as a JSON file with a list of features."
             data = json.loads(stream.getvalue().decode('utf-8'))

--- a/spacer/data_classes.py
+++ b/spacer/data_classes.py
@@ -115,7 +115,7 @@ class PointFeatures(DataClass):
     def __init__(self,
                  row: Optional[int],  # Row where feature was extracted
                  col: Optional[int],  # Column where feature was extracted
-                 data: np.array,  # Feature vector. 32 bit precision floats.
+                 data: np.array,  # Feature vector with half precision floats.
                  ):
         self.row = row
         self.col = col

--- a/spacer/data_classes.py
+++ b/spacer/data_classes.py
@@ -115,28 +115,23 @@ class PointFeatures(DataClass):
     def __init__(self,
                  row: Optional[int],  # Row where feature was extracted
                  col: Optional[int],  # Column where feature was extracted
-                 data: List[float],  # Feature vector as list of floats.
+                 data: np.array,  # Feature vector. 32 bit precision floats.
                  ):
         self.row = row
         self.col = col
-        self.data = data
+        self.data = np.array(data, dtype=np.float)
 
     @classmethod
     def example(cls):
         return cls(
             row=100,
             col=100,
-            data=[1.1, 1.3, 1.12]
+            data=np.array([1.1, 1.3, 1.12], dtype=np.float)
         )
 
-    @classmethod
-    def deserialize(cls, data: Dict) -> 'PointFeatures':
-        """ Redefined here to help the Typing module. """
-        return cls(**data)
-
-    @property
-    def data_np(self):
-        return np.array(self.data).reshape(1, -1)
+    def __eq__(self, other):
+        return self.row == other.row and self.col == other.col and \
+               np.allclose(self.data, other.data)
 
 
 class ImageFeatures(DataClass):
@@ -195,35 +190,22 @@ class ImageFeatures(DataClass):
     @classmethod
     def deserialize(cls, data: Union[Dict, List]) -> 'ImageFeatures':
 
-        if isinstance(data, List):
-            # Legacy feature were stored as a list of list
-            # without row and column information.
-            assert len(data) > 0, "Empty features file."
-            return ImageFeatures(
-                point_features=[PointFeatures(row=None,
-                                              col=None,
-                                              data=entry) for entry in data],
-                valid_rowcol=False,
-                feature_dim=len(data[0]),
-                npoints=len(data)
-            )
-        else:
-            return ImageFeatures(
-                point_features=[PointFeatures.deserialize(feat)
-                                for feat in data['point_features']],
-                valid_rowcol=data['valid_rowcol'],
-                feature_dim=data['feature_dim'],
-                npoints=data['npoints']
-            )
+        assert isinstance(data, List), \
+            "Deserialize only supported for legacy format"
+        # Legacy feature were stored as a list of list
+        # without row and column information.
+        assert len(data) > 0, "Empty features file."
+        return ImageFeatures(
+            point_features=[PointFeatures(row=None,
+                                          col=None,
+                                          data=entry) for entry in data],
+            valid_rowcol=False,
+            feature_dim=len(data[0]),
+            npoints=len(data)
+        )
 
     def serialize(self):
-        return {
-            'point_features': [feats.serialize() for
-                               feats in self.point_features],
-            'valid_rowcol': self.valid_rowcol,
-            'feature_dim': self.feature_dim,
-            'npoints': self.npoints
-        }
+        raise DeprecationWarning('Use .store() and .load() methods instead.')
 
     def __eq__(self, other):
         return all([a == b for a, b in zip(self.point_features,
@@ -245,6 +227,57 @@ class ImageFeatures(DataClass):
                              valid_rowcol=True,
                              feature_dim=feature_dim,
                              npoints=len(point_labels))
+
+    @classmethod
+    def load(cls, loc: 'DataLocation'):
+
+        storage = storage_factory(loc.storage_type, loc.bucket_name)
+        stream = storage.load(loc.key)
+        try:
+            stream.seek(0)
+            data = np.load(stream)
+            valid_rowcol = data['meta'][0]
+            if valid_rowcol:
+                return ImageFeatures(
+                    point_features=[PointFeatures(
+                        row=int(row),
+                        col=int(col),
+                        data=feat) for row, col, feat in zip(data['rows'],
+                                                             data['cols'],
+                                                             data['feat'])],
+                    valid_rowcol=data['meta'][0],
+                    npoints=data['meta'][1],
+                    feature_dim=data['meta'][2]
+                )
+            else:
+                return ImageFeatures(
+                    point_features=[PointFeatures(
+                        row=None,
+                        col=None,
+                        data=feat) for feat in data['feat']],
+                    valid_rowcol=data['meta'][0],
+                    npoints=data['meta'][1],
+                    feature_dim=data['meta'][2]
+                )
+        except ValueError:
+            "We used to store these as a JSON file with a list of features."
+            data = json.loads(stream.getvalue().decode('utf-8'))
+            return cls.deserialize(data)
+
+    def store(self, loc: 'DataLocation'):
+        storage = storage_factory(loc.storage_type, loc.bucket_name)
+        if self.valid_rowcol:
+            rows = np.array([p.row for p in self.point_features], dtype=np.uint16)
+            cols = np.array([p.col for p in self.point_features], dtype=np.uint16)
+        else:
+            rows = np.array([])
+            cols = np.array([])
+        feat = np.array([p.data for p in self.point_features], dtype=np.float)
+        meta = np.array([self.valid_rowcol, self.npoints, self.feature_dim])
+        output = BytesIO()
+        np.savez_compressed(output, meta=meta, rows=rows, cols=cols, feat=feat)
+        output.seek(0)
+        storage.store(loc.key, output)
 
 
 class ValResults(DataClass):

--- a/spacer/tasks.py
+++ b/spacer/tasks.py
@@ -74,7 +74,8 @@ def classify_features(msg: ClassifyFeaturesMsg) -> ClassifyReturnMsg:
 
     clf = load_classifier(msg.classifier_loc)
 
-    scores = [(pf.row, pf.col, clf.predict_proba(pf.data_np).tolist()[0]) for
+    scores = [(pf.row, pf.col,
+               clf.predict_proba(pf.data.reshape(1, -1)).tolist()[0]) for
               pf in features.point_features]
 
     # Return

--- a/spacer/tests/test_beta_regression.py
+++ b/spacer/tests/test_beta_regression.py
@@ -180,7 +180,7 @@ class TestClassifyFeatures(unittest.TestCase):
 
         for ls, ns in zip(legacy_return.scores, new_return.scores):
             with self.subTest(im_key=im_key, clf_key=clf_key):
-                self.assertTrue(np.allclose(ls[2], ns[2]))
+                self.assertTrue(np.allclose(ls[2], ns[2], atol=1e-3))
 
     def test_all(self):
 

--- a/spacer/tests/test_beta_regression.py
+++ b/spacer/tests/test_beta_regression.py
@@ -139,7 +139,7 @@ class TestExtractFeatures(unittest.TestCase):
                                          new_feats.point_features,
                                          msg.rowcols):
             self.assertTrue(np.allclose(legacy_pf.data, new_pf.data,
-                                        atol=1e-5))
+                                        atol=1e-3))
 
 
 @unittest.skipUnless(config.HAS_S3_TEST_ACCESS, 'No access to tests')

--- a/spacer/tests/test_beta_regression.py
+++ b/spacer/tests/test_beta_regression.py
@@ -139,7 +139,7 @@ class TestExtractFeatures(unittest.TestCase):
                                          new_feats.point_features,
                                          msg.rowcols):
             self.assertTrue(np.allclose(legacy_pf.data, new_pf.data,
-                                        atol=1e-3))
+                                        atol=1e-5))
 
 
 @unittest.skipUnless(config.HAS_S3_TEST_ACCESS, 'No access to tests')
@@ -180,7 +180,7 @@ class TestClassifyFeatures(unittest.TestCase):
 
         for ls, ns in zip(legacy_return.scores, new_return.scores):
             with self.subTest(im_key=im_key, clf_key=clf_key):
-                self.assertTrue(np.allclose(ls[2], ns[2], atol=1e-3))
+                self.assertTrue(np.allclose(ls[2], ns[2]))
 
     def test_all(self):
 

--- a/spacer/tests/test_data_classes.py
+++ b/spacer/tests/test_data_classes.py
@@ -53,7 +53,7 @@ class TestImageFeatures(unittest.TestCase):
     def test_getitem(self):
         msg = ImageFeatures.example()
         point_features = msg[(100, 100)]
-        self.assertAlmostEqual(point_features[0], 1.1, places=3)
+        self.assertAlmostEqual(point_features[0], 1.1)
 
     def test_legacy_getitme(self):
         msg = ImageFeatures.example()

--- a/spacer/tests/test_data_classes.py
+++ b/spacer/tests/test_data_classes.py
@@ -61,6 +61,7 @@ class TestImageFeatures(unittest.TestCase):
         self.assertRaises(ValueError, msg.__getitem__, (100, 100))
 
 
+@unittest.skipUnless(config.HAS_S3_TEST_ACCESS, 'No access to test bucket')
 class TestImageFeaturesNumpyStore(unittest.TestCase):
 
     def setUp(self) -> None:
@@ -88,7 +89,6 @@ class TestImageFeaturesNumpyStore(unittest.TestCase):
         s3 = config.get_s3_conn()
         s3.Object(config.TEST_BUCKET, self.s3_loc.key).delete()
 
-    @unittest.skipUnless(config.HAS_S3_TEST_ACCESS, 'No access to test bucket')
     def test_s3(self):
         self._test_numpy_store(self.s3_loc)
 

--- a/spacer/tests/test_data_classes.py
+++ b/spacer/tests/test_data_classes.py
@@ -53,7 +53,7 @@ class TestImageFeatures(unittest.TestCase):
     def test_getitem(self):
         msg = ImageFeatures.example()
         point_features = msg[(100, 100)]
-        self.assertAlmostEqual(point_features[0], 1.1)
+        self.assertAlmostEqual(point_features[0], 1.1, places=3)
 
     def test_legacy_getitme(self):
         msg = ImageFeatures.example()

--- a/spacer/tests/test_data_classes.py
+++ b/spacer/tests/test_data_classes.py
@@ -88,6 +88,7 @@ class TestImageFeaturesNumpyStore(unittest.TestCase):
         s3 = config.get_s3_conn()
         s3.Object(config.TEST_BUCKET, self.s3_loc.key).delete()
 
+    @unittest.skipUnless(config.HAS_S3_TEST_ACCESS, 'No access to test bucket')
     def test_s3(self):
         self._test_numpy_store(self.s3_loc)
 

--- a/spacer/tests/test_data_classes.py
+++ b/spacer/tests/test_data_classes.py
@@ -1,6 +1,7 @@
 import json
 import os
 import unittest
+import random
 
 from spacer import config
 from spacer.data_classes import \
@@ -16,30 +17,11 @@ class TestDataClass(unittest.TestCase):
 
     def test_repr(self):
         pf = PointFeatures.example()
-        self.assertEqual(str(pf),
-                         "{'col': 100, 'data': [1.1, 1.3, 1.12], 'row': 100}")
-
-
-class TestPointFeatures(unittest.TestCase):
-
-    def test_serialize(self):
-
-        msg = PointFeatures.example()
-        self.assertEqual(msg, PointFeatures.deserialize(
-            msg.serialize()))
-        self.assertEqual(msg, PointFeatures.deserialize(
-            json.loads(json.dumps(msg.serialize()))))
+        self.assertIn("'col': 100", str(pf))
+        self.assertIn("'row': 100", str(pf))
 
 
 class TestImageFeatures(unittest.TestCase):
-
-    def test_serialize(self):
-
-        msg = ImageFeatures.example()
-        self.assertEqual(msg, ImageFeatures.deserialize(
-            msg.serialize()))
-        self.assertEqual(msg, ImageFeatures.deserialize(
-            json.loads(json.dumps(msg.serialize()))))
 
     def test_legacy(self):
         """
@@ -49,16 +31,10 @@ class TestImageFeatures(unittest.TestCase):
                                'legacy.jpg.feats')) as fp:
             feats = ImageFeatures.deserialize(json.load(fp))
         self.assertEqual(feats.valid_rowcol, False)
-        self.assertEqual(ImageFeatures.deserialize(
-            feats.serialize()).valid_rowcol, False)
 
         self.assertTrue(isinstance(feats.point_features[0], PointFeatures))
         self.assertEqual(feats.npoints, len(feats.point_features))
         self.assertEqual(feats.feature_dim, len(feats.point_features[0].data))
-
-        self.assertEqual(feats, ImageFeatures.deserialize(feats.serialize()))
-        self.assertEqual(feats, ImageFeatures.deserialize(json.loads(
-            json.dumps(feats.serialize()))))
 
     @unittest.skipUnless(config.HAS_S3_TEST_ACCESS, 'No access to test bucket')
     def test_legacy_from_s3(self):
@@ -68,18 +44,77 @@ class TestImageFeatures(unittest.TestCase):
 
         feats = ImageFeatures.load(legacy_feat_loc)
         self.assertEqual(feats.valid_rowcol, False)
-        self.assertEqual(feats, ImageFeatures.deserialize(json.loads(
-            json.dumps(feats.serialize()))))
+
+        mem_loc = DataLocation(storage_type='memory', key='tmp')
+        feats.store(mem_loc)
+        reloaded_feats = ImageFeatures.load(mem_loc)
+        self.assertEqual(feats, reloaded_feats)
 
     def test_getitem(self):
         msg = ImageFeatures.example()
         point_features = msg[(100, 100)]
-        self.assertEqual(point_features[0], 1.1)
+        self.assertAlmostEqual(point_features[0], 1.1, places=3)
 
     def test_legacy_getitme(self):
         msg = ImageFeatures.example()
         msg.valid_rowcol = False
         self.assertRaises(ValueError, msg.__getitem__, (100, 100))
+
+
+class TestImageFeaturesNumpyStore(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.fs_loc = DataLocation(
+                storage_type='filesystem',
+                key='tmp/tmp_feats',
+                bucket_name='')
+        self.s3_loc = DataLocation(
+            storage_type='s3',
+            key='tmp_feats',
+            bucket_name=config.TEST_BUCKET
+        )
+        self.mem_loc = DataLocation(
+            storage_type='memory',
+            key='tmp_feats'
+        )
+
+    def tearDown(self):
+
+        if os.path.exists(self.fs_loc.key):
+            os.remove(self.fs_loc.key)
+        dirname = os.path.abspath(os.path.dirname(self.fs_loc.key))
+        if os.path.exists(dirname):
+            os.rmdir(dirname)
+        s3 = config.get_s3_conn()
+        s3.Object(config.TEST_BUCKET, self.s3_loc.key).delete()
+
+    def test_s3(self):
+        self._test_numpy_store(self.s3_loc)
+
+    def test_fs(self):
+        self._test_numpy_store(self.fs_loc)
+
+    def test_mem(self):
+        self._test_numpy_store(self.mem_loc)
+
+    def _test_numpy_store(self, feat_loc):
+
+        n_pts = 200
+        n_dim = 1280
+        feats = ImageFeatures(
+            point_features=[PointFeatures(row=i,
+                                          col=i,
+                                          data=[random.random()]*n_dim)
+                            for i in range(n_pts)],
+            valid_rowcol=True,
+            feature_dim=n_dim,
+            npoints=n_pts
+        )
+        with config.log_entry_and_exit('Storing feats vector'):
+            feats.store(feat_loc)
+
+        feats_reloaded = ImageFeatures.load(feat_loc)
+        self.assertEqual(feats, feats_reloaded)
 
 
 class TestFeatureLabels(unittest.TestCase):

--- a/spacer/tests/test_data_classes.py
+++ b/spacer/tests/test_data_classes.py
@@ -116,6 +116,10 @@ class TestImageFeaturesNumpyStore(unittest.TestCase):
         feats_reloaded = ImageFeatures.load(feat_loc)
         self.assertEqual(feats, feats_reloaded)
 
+    def test_deprecated_serializer(self):
+        feats = ImageFeatures.example()
+        self.assertRaises(NotImplementedError, feats.serialize)
+
 
 class TestFeatureLabels(unittest.TestCase):
 

--- a/spacer/tests/test_extract_features.py
+++ b/spacer/tests/test_extract_features.py
@@ -174,7 +174,7 @@ class TestCaffeExtractor(unittest.TestCase):
         for pf_new, pf_legacy in zip(features_new.point_features,
                                      features_legacy.point_features):
             self.assertTrue(np.allclose(pf_legacy.data, pf_new.data,
-                                        atol=1e-3))
+                                        atol=1e-5))
             self.assertTrue(pf_legacy.row is None)
             self.assertTrue(pf_new.row is not None)
 

--- a/spacer/tests/test_extract_features.py
+++ b/spacer/tests/test_extract_features.py
@@ -174,7 +174,7 @@ class TestCaffeExtractor(unittest.TestCase):
         for pf_new, pf_legacy in zip(features_new.point_features,
                                      features_legacy.point_features):
             self.assertTrue(np.allclose(pf_legacy.data, pf_new.data,
-                                        atol=1e-5))
+                                        atol=1e-3))
             self.assertTrue(pf_legacy.row is None)
             self.assertTrue(pf_new.row is not None)
 

--- a/spacer/tests/test_train_utils.py
+++ b/spacer/tests/test_train_utils.py
@@ -2,6 +2,8 @@ import itertools
 import unittest
 from typing import Tuple
 
+import numpy as np
+
 from spacer import config
 from spacer.data_classes import ImageLabels, PointFeatures, ImageFeatures
 from spacer.messages import DataLocation
@@ -255,7 +257,7 @@ class TestLoadImageData(unittest.TestCase):
         x, y = load_image_data(labels, self.feat_key, [1, 2], self.feature_loc)
 
         self.assertEqual(y, [1, 2, 1])
-        self.assertEqual(x[0], features.point_features[0].data)
+        self.assertTrue(np.array_equal(x[0], features.point_features[0].data))
 
     def test_reverse(self):
         """ here the order of features and labels are reversed.
@@ -268,7 +270,7 @@ class TestLoadImageData(unittest.TestCase):
         self.assertEqual(y, [1, 2, 1])
         # Since the order is reversed, the first feature should be the second
         # vector of point_features list.
-        self.assertEqual(x[0], features.point_features[1].data)
+        self.assertTrue(np.array_equal(x[0], features.point_features[1].data))
 
     def test_legacy_reverse(self):
         """
@@ -282,7 +284,7 @@ class TestLoadImageData(unittest.TestCase):
         self.assertEqual(y, [1, 2, 1])
         # Since the order is reversed, the first feature should be the second
         # vector of point_features list. But it is not.
-        self.assertNotEqual(x[0], features.point_features[1].data)
+        self.assertFalse(np.array_equal(x[0], features.point_features[1].data))
 
     def test_smaller_labelset(self):
         """ Here we use a smaller labelset and assert
@@ -293,8 +295,8 @@ class TestLoadImageData(unittest.TestCase):
         x, y = load_image_data(labels, self.feat_key, [1], self.feature_loc)
 
         self.assertEqual(y, [1, 1])
-        self.assertEqual(x[0], features.point_features[0].data)
-        self.assertEqual(x[1], features.point_features[2].data)
+        self.assertTrue(np.array_equal(x[0], features.point_features[0].data))
+        self.assertTrue(np.array_equal(x[1], features.point_features[2].data))
 
     def test_other_small_labelset(self):
         """ Here we use a smaller labelset and assert
@@ -305,7 +307,7 @@ class TestLoadImageData(unittest.TestCase):
         x, y = load_image_data(labels, self.feat_key, [2], self.feature_loc)
 
         self.assertEqual(y, [2])
-        self.assertEqual(x[0], features.point_features[1].data)
+        self.assertTrue(np.array_equal(x[0], features.point_features[1].data))
 
     def test_legacy_smaller_labelset(self):
         """
@@ -319,8 +321,8 @@ class TestLoadImageData(unittest.TestCase):
         self.assertEqual(y, [1, 1])
         # Since the order is reversed, the first feature should be the second
         # vector of point_features list. But it is not.
-        self.assertEqual(x[0], features.point_features[0].data)
-        self.assertEqual(x[1], features.point_features[2].data)
+        self.assertTrue(np.array_equal(x[0], features.point_features[0].data))
+        self.assertTrue(np.array_equal(x[1], features.point_features[2].data))
 
 
 class TestLoadBatchData(unittest.TestCase):
@@ -379,16 +381,16 @@ class TestLoadBatchData(unittest.TestCase):
         x, y = load_batch_data(labels, [self.feat_key1, self.feat_key2],
                                [1, 2], self.feat_loc_template)
 
-        self.assertEqual(x[0], features1.point_features[0].data)
-        self.assertEqual(x[3], features2.point_features[0].data)
+        self.assertTrue(np.array_equal(x[0], features1.point_features[0].data))
+        self.assertTrue(np.array_equal(x[3], features2.point_features[0].data))
 
     def test_reverse_imkey_order(self):
         labels, features1, features2 = self.fixtures(valid_rowcol=True)
         x, y = load_batch_data(labels, [self.feat_key2, self.feat_key1],
                                [1, 2], self.feat_loc_template)
 
-        self.assertEqual(x[0], features2.point_features[0].data)
-        self.assertEqual(x[3], features1.point_features[0].data)
+        self.assertTrue(np.array_equal(x[0], features2.point_features[0].data))
+        self.assertTrue(np.array_equal(x[3], features1.point_features[0].data))
 
     def test_one_label(self):
 


### PR DESCRIPTION
This PR writes a custom `.store()` and `.load()` method for `ImageFeatures`. 

It reduces storage from 271k to 24k for the example below with 10 feature vectors from `efficientnet_b0_ver1`. Storage time to local changed from 0.01 to 0.003 seconds.

Further, this changes to using `np.half` inside the `PointFeatures` class so training on these features should be faster also. https://github.com/qiminchen/CoralNet/issues/13

Question: I could settle for np.float (32 bit precision) at twice the storage cost. I'm not sure which is better.

### To test
To test run e.g. the code below on master and on this branch and check the file-size on disk. 

```
from spacer.messages import ExtractFeaturesMsg
from spacer.tasks import extract_features
msg = ExtractFeaturesMsg(
        job_token='asdas',
        feature_extractor_name='efficientnet_b0_ver1',
        rowcols=[(i, i) for i in range(10)],
        image_loc=DataLocation(
            storage_type='s3',
            bucket_name='spacer-test',
            key='08bfc10v7t.png'),
        feature_loc=DataLocation(
            storage_type='filesystem',
            key='tmp.feats'
        )
    )
_ = extract_features(msg)
```