### PR TITLE
Replace test image URL; original is no longer available

### DIFF
--- a/spacer/tests/test_mailman.py
+++ b/spacer/tests/test_mailman.py
@@ -12,16 +12,19 @@ from spacer.messages import \
     DataLocation, \
     ImageLabels
 
+TEST_URL = \
+    'https://upload.wikimedia.org/wikipedia/commons/7/7b/Red_sea_coral_reef.jpg'
+TEST_URL_FILENAME = 'Red_sea_coral_reef.jpg'
+
 
 class TestProcessJobErrorHandling(unittest.TestCase):
 
     def setUp(self):
         config.filter_warnings()
-        self.url = 'https://homepages.cae.wisc.edu/~ece533/images/baboon.png'
 
     def tearDown(self):
-        if os.path.exists('baboon.png'):
-            os.remove('baboon.png')
+        if os.path.exists(TEST_URL_FILENAME):
+            os.remove(TEST_URL_FILENAME)
 
     def test_input_type(self):
         self.assertRaises(AssertionError, process_job, 'sdf')
@@ -69,7 +72,7 @@ class TestProcessJobErrorHandling(unittest.TestCase):
                      tasks=[ClassifyImageMsg(
                          job_token='my_job',
                          image_loc=DataLocation(storage_type='url',
-                                                key=self.url),
+                                                key=TEST_URL),
                          feature_extractor_name='invalid_name',
                          rowcols=[(1, 1)],
                          classifier_loc=DataLocation(storage_type='memory',
@@ -87,7 +90,7 @@ class TestProcessJobErrorHandling(unittest.TestCase):
                      tasks=[ClassifyImageMsg(
                          job_token='my_job',
                          image_loc=DataLocation(storage_type='url',
-                                                key=self.url),
+                                                key=TEST_URL),
                          feature_extractor_name='dummy',
                          rowcols=[(1, 1)],
                          classifier_loc=DataLocation(storage_type='memory',
@@ -136,11 +139,10 @@ class TestProcessJobMultiple(unittest.TestCase):
 
     def setUp(self):
         config.filter_warnings()
-        self.url = 'https://homepages.cae.wisc.edu/~ece533/images/baboon.png'
 
     def tearDown(self):
-        if os.path.exists('baboon.png'):
-            os.remove('baboon.png')
+        if os.path.exists(TEST_URL_FILENAME):
+            os.remove(TEST_URL_FILENAME)
 
     def test_multiple_feature_extract(self):
         extract_msg = ExtractFeaturesMsg(
@@ -148,7 +150,7 @@ class TestProcessJobMultiple(unittest.TestCase):
             feature_extractor_name='dummy',
             rowcols=[(1, 1)],
             image_loc=DataLocation(storage_type='url',
-                                   key=self.url),
+                                   key=TEST_URL),
             feature_loc=DataLocation(storage_type='memory',
                                      key='my_feats'))
 
@@ -166,7 +168,7 @@ class TestProcessJobMultiple(unittest.TestCase):
             feature_extractor_name='dummy',
             rowcols=[(1, 1)],
             image_loc=DataLocation(storage_type='url',
-                                   key=self.url),
+                                   key=TEST_URL),
             feature_loc=DataLocation(storage_type='memory',
                                      key='my_feats'))
 

--- a/spacer/tests/test_tasks.py
+++ b/spacer/tests/test_tasks.py
@@ -27,6 +27,9 @@ from spacer.tasks import \
 from spacer.train_utils import make_random_data
 from spacer.train_utils import train
 
+TEST_URL = \
+    'https://upload.wikimedia.org/wikipedia/commons/7/7b/Red_sea_coral_reef.jpg'
+
 
 class TestImageAndPointLimitsAsserts(unittest.TestCase):
 
@@ -340,8 +343,7 @@ class TestClassifyImage(ClassifyReturnMsgTest):
         msg = ClassifyImageMsg(
             job_token='my_job',
             image_loc=DataLocation(storage_type='url',
-                                   key='https://homepages.cae.wisc.edu/~ece533'
-                                       '/images/baboon.png'),
+                                   key=TEST_URL),
             feature_extractor_name='dummy',
             rowcols=[(100, 100), (200, 200)],
             classifier_loc=DataLocation(storage_type='s3',
@@ -369,8 +371,7 @@ class TestClassifyImageCache(unittest.TestCase):
         msg = ClassifyImageMsg(
             job_token='my_job',
             image_loc=DataLocation(storage_type='url',
-                                   key='https://homepages.cae.wisc.edu/~ece533'
-                                       '/images/baboon.png'),
+                                   key=TEST_URL),
             feature_extractor_name='dummy',
             rowcols=[(100, 100), (200, 200)],
             classifier_loc=DataLocation(storage_type='s3',
@@ -381,8 +382,7 @@ class TestClassifyImageCache(unittest.TestCase):
         msg2 = ClassifyImageMsg(
             job_token='my_job',
             image_loc=DataLocation(storage_type='url',
-                                   key='https://homepages.cae.wisc.edu/~ece533'
-                                       '/images/baboon.png'),
+                                   key=TEST_URL),
             feature_extractor_name='dummy',
             rowcols=[(100, 100), (200, 200)],
             classifier_loc=DataLocation(storage_type='s3',
@@ -403,8 +403,7 @@ class TestBadRowcols(unittest.TestCase):
         msg = ClassifyImageMsg(
             job_token='my_job',
             image_loc=DataLocation(storage_type='url',
-                                   key='https://homepages.cae.wisc.edu/~ece533'
-                                       '/images/baboon.png'),
+                                   key=TEST_URL),
             feature_extractor_name='dummy',
             rowcols=[(-1, -1)],
             classifier_loc=DataLocation(storage_type='s3',


### PR DESCRIPTION
The wisc.edu baboon image URL, used in some unit tests, is no longer available. This PR switches the URL to a Wikimedia image of roughly similar size.

@beijbom : I was working on a small change to spacer, in hopes of stopping error emails from deploy-requests of unreachable image URLs, but I ran into this issue first. Do you think you'll be able to review infrequent spacer PRs like this for the foreseeable future? (This repo requires 1 approving review to merge PRs.)