### PR TITLE
GH Action: Try older pip versions on the scikit-image install

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -22,7 +22,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install pip==19.3
         pip install -r requirements.txt
     - name: Make directories
       run: |


### PR DESCRIPTION
This old Travis build succeeded with pip 19.3: https://travis-ci.org/github/beijbom/pyspacer/jobs/725155186

Current pip is 22.0.4 and fails to build the same version of scikit-image: https://github.com/beijbom/pyspacer/runs/5561549826

I'll see if 19.3 makes it work again. If so, I might narrow down the pip version more out of curiosity. Then I'll think about what to do from there to fix the builds with current pip.