### PR TITLE
Raise different error class for image-download errors

### DIFF
--- a/spacer/exceptions.py
+++ b/spacer/exceptions.py
@@ -1,0 +1,7 @@
+class SpacerInputError(Exception):
+    """
+    This should indicate that the exception was not caused by a spacer bug, but
+    by giving inputs that spacer cannot reasonably handle. For example, an
+    unreachable URL given as the image URL to download.
+    """
+    pass

--- a/spacer/storage.py
+++ b/spacer/storage.py
@@ -18,6 +18,7 @@ from PIL import Image
 from sklearn.calibration import CalibratedClassifierCV
 
 from spacer import config
+from spacer.exceptions import SpacerInputError
 
 
 class Storage(abc.ABC):  # pragma: no cover
@@ -49,7 +50,10 @@ class URLStorage(Storage):
         raise TypeError('Store operation not supported for URL storage.')
 
     def load(self, url: str):
-        tmp_path = wget.download(url)
+        try:
+            tmp_path = wget.download(url)
+        except URLError as e:
+            raise SpacerInputError(str(e))
         stream = self.fs_storage.load(tmp_path)
         self.fs_storage.delete(tmp_path)
         return stream

--- a/spacer/tests/test_mailman.py
+++ b/spacer/tests/test_mailman.py
@@ -48,7 +48,7 @@ class TestProcessJobErrorHandling(unittest.TestCase):
         self.assertFalse(return_msg.ok)
         self.assertIn("KeyError", return_msg.error_message)
         self.assertIn("missing_image", return_msg.error_message)
-        self.assertTrue(type(return_msg), JobReturnMsg)
+        self.assertEqual(type(return_msg), JobReturnMsg)
 
     def test_img_classify_bad_url(self):
 
@@ -65,7 +65,7 @@ class TestProcessJobErrorHandling(unittest.TestCase):
         self.assertFalse(return_msg.ok)
         self.assertIn("URLError", return_msg.error_message)
         self.assertIn("SpacerInputError", return_msg.error_message)
-        self.assertTrue(type(return_msg), JobReturnMsg)
+        self.assertEqual(type(return_msg), JobReturnMsg)
 
     def test_img_classify_feature_extractor_name(self):
 
@@ -83,7 +83,7 @@ class TestProcessJobErrorHandling(unittest.TestCase):
         self.assertIn("AssertionError", return_msg.error_message)
         self.assertIn("Model name invalid_name not registered",
                       return_msg.error_message)
-        self.assertTrue(type(return_msg), JobReturnMsg)
+        self.assertEqual(type(return_msg), JobReturnMsg)
 
     def test_img_classify_classifier_key(self):
 
@@ -101,7 +101,7 @@ class TestProcessJobErrorHandling(unittest.TestCase):
         self.assertFalse(return_msg.ok)
         self.assertIn("KeyError", return_msg.error_message)
         self.assertIn("no_classifier_here", return_msg.error_message)
-        self.assertTrue(type(return_msg), JobReturnMsg)
+        self.assertEqual(type(return_msg), JobReturnMsg)
 
     def test_train_classifier(self):
 
@@ -133,7 +133,7 @@ class TestProcessJobErrorHandling(unittest.TestCase):
             self.assertFalse(return_msg.ok)
             self.assertIn("KeyError", return_msg.error_message)
             self.assertIn("my_previous_model", return_msg.error_message)
-            self.assertTrue(type(return_msg), JobReturnMsg)
+            self.assertEqual(type(return_msg), JobReturnMsg)
 
 
 class TestProcessJobMultiple(unittest.TestCase):
@@ -161,7 +161,7 @@ class TestProcessJobMultiple(unittest.TestCase):
         return_msg = process_job(job_msg)
         self.assertTrue(return_msg.ok)
         self.assertEqual(len(return_msg.results), 2)
-        self.assertTrue(type(return_msg), JobReturnMsg)
+        self.assertEqual(type(return_msg), JobReturnMsg)
 
     def test_multiple_feature_extract_one_fail(self):
         good_extract_msg = ExtractFeaturesMsg(
@@ -189,7 +189,7 @@ class TestProcessJobMultiple(unittest.TestCase):
         return_msg = process_job(job_msg)
         self.assertFalse(return_msg.ok)
         self.assertIn('bad_url', return_msg.error_message)
-        self.assertTrue(type(return_msg), JobReturnMsg)
+        self.assertEqual(type(return_msg), JobReturnMsg)
 
 
 if __name__ == '__main__':

--- a/spacer/tests/test_mailman.py
+++ b/spacer/tests/test_mailman.py
@@ -63,7 +63,8 @@ class TestProcessJobErrorHandling(unittest.TestCase):
                                                      key='doesnt_matter'))])
         return_msg = process_job(msg)
         self.assertFalse(return_msg.ok)
-        self.assertTrue('URLError' in return_msg.error_message)
+        self.assertIn("URLError", return_msg.error_message)
+        self.assertIn("SpacerInputError", return_msg.error_message)
         self.assertTrue(type(return_msg), JobReturnMsg)
 
     def test_img_classify_feature_extractor_name(self):

--- a/spacer/tests/test_tasks.py
+++ b/spacer/tests/test_tasks.py
@@ -123,7 +123,7 @@ class TestExtractFeatures(unittest.TestCase):
                                      key='feats')
         )
         return_msg = extract_features(msg)
-        self.assertTrue(type(return_msg) == ExtractFeaturesReturnMsg)
+        self.assertEqual(type(return_msg), ExtractFeaturesReturnMsg)
         storage = storage_factory('memory')
         self.assertTrue(storage.exists('feats'))
 
@@ -193,11 +193,11 @@ class TestTrainClassifier(unittest.TestCase):
                 valresult_loc=valresult_loc
             )
             return_msg = train_classifier(msg)
-            self.assertTrue(type(return_msg) == TrainClassifierReturnMsg)
+            self.assertEqual(type(return_msg), TrainClassifierReturnMsg)
 
             # Do some checks on ValResults
             val_res = ValResults.load(valresult_loc)
-            self.assertTrue(type(val_res) == ValResults)
+            self.assertEqual(type(val_res), ValResults)
             self.assertEqual(len(val_res.gt), len(val_res.est))
             self.assertEqual(len(val_res.gt), len(val_res.scores))
 
@@ -287,7 +287,7 @@ class ClassifyReturnMsgTest(unittest.TestCase):
 
         self.assertTrue(isinstance(return_msg.valid_rowcol, bool))
 
-        self.assertTrue(type(return_msg.scores), ClassifyReturnMsg)
+        self.assertEqual(type(return_msg), ClassifyReturnMsg)
 
 
 class TestClassifyFeatures(ClassifyReturnMsgTest):


### PR DESCRIPTION
CoralNet sends admin emails whenever spacer jobs return with an error. This has included Deploy jobs where the user-provided image URL was unreachable. That is generally a user-error situation (e.g. didn't provide a public URL), not a spacer bug, so it's not particularly useful for us to get emails when that happens.

In this PR I tried to catch that particular case (without masking other types of errors) and raise a `SpacerInputError` when it happens. Then when CoralNet's vision backend gets a `SpacerInputError` back from spacer, it can realize "oh, this isn't a spacer bug, the issue was the inputs given to spacer, so I won't email the admins." I've got a CoralNet-repo PR lined up to complete that logic, though it won't actually work unless this spacer PR is merged into the master branch.

(In the meantime, I saw some `assertTrue` usages which seemed like they were meant to be `assertEqual`, so I made a second commit to change those. Let me know if I was mistaken here though.)